### PR TITLE
Allow for spacing around '='

### DIFF
--- a/UpgradeRepo/Cpm/ProjectFileHelpers.cs
+++ b/UpgradeRepo/Cpm/ProjectFileHelpers.cs
@@ -9,15 +9,15 @@ namespace UpgradeRepo.Cpm
 {
     internal static class ProjectFileHelpers
     {
-        private const string PackageReferenceVersionPattern = " Version=\"[^\"]*\"";
-        private const string PackageRefStartPattern = @"<PackageReference\s+Include=""(?<name>[^""]+)""";
-        private const string VersionAttrPattern = @"Version=""(?<version>[^""]+)""";
+        private const string PackageReferenceVersionPattern = " Version\\s*=\\s*\"[^\"]*\"";
+        private const string PackageRefStartPattern = @"<PackageReference\s+Include\s*=\s*""(?<name>[^""]+)""";
+        private const string VersionAttrPattern = @"Version\s*=\s*""(?<version>[^""]+)""";
         private const string VersionTagPattern = "<Version>(?<version>[^<]+)</Version>";
         private const string PackageReferenceCloseTagPattern = "</PackageReference>";
         private const string PackageReferenceClosedPattern = "<PackageReference[^>]*\\/>";
         private const string EmptyPackageReferencePattern = """<PackageReference ([^>]+)\s*>\s*</PackageReference>""";
         private const string EmptyPackageReferenceReplacement = "<PackageReference $1/>";
-        private const string PackageReferenceUpdatePattern = """<PackageReference\s+Update="(?<name>[^"]+)"\s+(.*?)Version="(?<version>[^"]+)"([^/>]*)(\/?)>""";
+        private const string PackageReferenceUpdatePattern = """<PackageReference\s+Update\s*=\s*"(?<name>[^"]+)"\s+(.*?)Version\s*=\s*"(?<version>[^"]+)"([^/>]*)(\/?)>""";
         private const string PackageReferenceUpdateReplacement = """<PackageReference Update="${name}" $1VersionOverride="${version}"$2$3>""";
 
         private static readonly Regex PackageRefStartRegex = new Regex(PackageRefStartPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/UpgradeRepoTests/CpmTests.cs
+++ b/UpgradeRepoTests/CpmTests.cs
@@ -546,6 +546,31 @@ namespace UpgradeRepoTests
         }
 
         [Fact]
+        public async Task WeirdSpacingHandled()
+        {
+            var contents = """<PackageReference Include = "Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version = "5.0.0-beta.3" />""";
+
+            var fs = TestProjectFile.CreateProjectFile(contents);
+
+            var vpvm = new CpmUpgradePlugin(new LoggerFactory().CreateLogger<CpmUpgradePlugin>(), null);
+            await vpvm.ApplyAsync(new OperateContext(fs, null));
+            var packages = vpvm.GetPackages().ToList();
+
+            vpvm.GetPackages().Count().ShouldBe(1);
+
+            fs.Files.First().Value.ShouldBe("""<PackageReference Include = "Microsoft.Azure.WebJobs.Extensions.ServiceBus" />""");
+
+            fs.Files[CpmUpgradePlugin.DirectoryPackagesProps].ShouldBe("""
+                                                                       <Project>
+                                                                         <ItemGroup>
+                                                                           <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.0.0-beta.3" />
+                                                                         </ItemGroup>
+                                                                       </Project>
+
+                                                                       """);
+        }
+
+        [Fact]
         public async Task PackageRefUpdateHandled2()
         {
             var contents =


### PR DESCRIPTION
Currently a PackageReference with spacing around the '=' wouldn't be properly upgraded. Eg:

```xml
<PackageReference Include = "Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version = "5.0.0-beta.3" />
```