### PR TITLE
Trim package names and versions

### DIFF
--- a/UpgradeRepo/Cpm/ProjectFileHelpers.cs
+++ b/UpgradeRepo/Cpm/ProjectFileHelpers.cs
@@ -43,7 +43,7 @@ namespace UpgradeRepo.Cpm
                 string? currentVersion = null;
                 if (packageRefMatch.Success)
                 {
-                    packageName = packageRefMatch.Groups["name"].Value;
+                    packageName = packageRefMatch.Groups["name"].Value.Trim();
 
                     if (!PackageReferenceClosedRegex.Match(line).Success)
                     {
@@ -54,7 +54,7 @@ namespace UpgradeRepo.Cpm
                     var versionMatch = VersionAttrRegex.Match(line);
                     if (versionMatch.Success)
                     {
-                        currentVersion = versionMatch.Groups["version"].Value;
+                        currentVersion = versionMatch.Groups["version"].Value.Trim();
                         packageReferences.Add(new Package(packageName, currentVersion));
                         continue;
                     }
@@ -71,7 +71,7 @@ namespace UpgradeRepo.Cpm
                     var versionMatch = VersionTagRegex.Match(line);
                     if (versionMatch.Success)
                     {
-                        currentVersion = versionMatch.Groups["version"].Value;
+                        currentVersion = versionMatch.Groups["version"].Value.Trim();
                         packageReferences.Add(new Package(packageName, currentVersion));
                     }
                 }
@@ -98,7 +98,7 @@ namespace UpgradeRepo.Cpm
                 string? currentVersion = null;
                 if (packageRefMatch.Success)
                 {
-                    packageName = packageRefMatch.Groups["name"].Value;
+                    packageName = packageRefMatch.Groups["name"].Value.Trim();
 
                     if (!PackageReferenceClosedRegex.Match(line).Success)
                     {
@@ -118,7 +118,7 @@ namespace UpgradeRepo.Cpm
                     var versionMatch = VersionAttrRegex.Match(line);
                     if (versionMatch.Success)
                     {
-                        currentVersion = versionMatch.Groups["version"].Value;
+                        currentVersion = versionMatch.Groups["version"].Value.Trim();
                         string newVersion = versionResolver(new Package(packageName, currentVersion));
 
                         newVersion = string.IsNullOrEmpty(newVersion)
@@ -155,7 +155,7 @@ namespace UpgradeRepo.Cpm
                     var versionMatch = VersionTagRegex.Match(line);
                     if (versionMatch.Success)
                     {
-                        currentVersion = versionMatch.Groups["version"].Value;
+                        currentVersion = versionMatch.Groups["version"].Value.Trim();
                         string newVersion = versionResolver(new Package(packageName, currentVersion));
 
                         newVersion = string.IsNullOrEmpty(newVersion)
@@ -206,8 +206,8 @@ namespace UpgradeRepo.Cpm
             {
                 foreach (Match match in matches)
                 {
-                    var name = match.Groups["name"].Value;
-                    var version = match.Groups["version"].Value;
+                    var name = match.Groups["name"].Value.Trim();
+                    var version = match.Groups["version"].Value.Trim();
 
                     var package = new Package(name, version);
                     if (package.VersionType == PackageVersionType.NuGetVersion)

--- a/UpgradeRepoTests/CpmTests.cs
+++ b/UpgradeRepoTests/CpmTests.cs
@@ -28,6 +28,20 @@ namespace UpgradeRepoTests
         }
 
         [Fact]
+        public async Task GetNameVersionTrimTest()
+        {
+            string line = """<PackageReference Include=" Microsoft.Azure.WebJobs.Extensions.ServiceBus " Version=" 5.0.0-beta.3 " />""";
+            var fs = TestProjectFile.GetRepo(line);
+            var vpvm = new CpmUpgradePlugin(new LoggerFactory().CreateLogger<CpmUpgradePlugin>(), null);
+            await vpvm.ApplyAsync(new OperateContext(fs, null));
+
+            var packages = vpvm.GetPackages().ToList();
+            packages.Count.ShouldBe(1);
+            packages[0].Name.ShouldBe("Microsoft.Azure.WebJobs.Extensions.ServiceBus");
+            packages[0].VersionString.ShouldBe("5.0.0-beta.3");
+        }
+
+        [Fact]
         public async Task RemoveVersionTest()
         {
             string line = """<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.0.0-beta.3"/>""";


### PR DESCRIPTION
This fixes an issue I've seen occasionally where a PackageReference which has an Include value with a trailing space will be trimmed properly by NuGet but not by this tool which leads to a Directory.Packages.props which is like:

```xml
<PackageVersion Include="Foo " Version="1.2.3" />
<PackageVersion Include="Foo" Version="4.5.6" />
```

which NuGet proceeds to complain about due to a duplicate `PackageVersion`.

This change simply trims the package name and version when extracting them.